### PR TITLE
Donate to Fablic.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Hidekazu Miyamoto
+Copyright (c) 2020 Rakuma
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,17 +2,15 @@
 
 To forward to GCP Cloud Logging as a Daemonset. It's inspired to [fluent/fluentd-kubernetes-daemonset](https://github.com/fluent/fluentd-kubernetes-daemonset)
 
-[![Docker Stars](https://img.shields.io/docker/stars/hiiiide/fluentd-ds-cloudlogging.svg)](https://hub.docker.com/r/hiiiide/fluentd-ds-cloudlogging)
-[![Docker Pulls](https://img.shields.io/docker/pulls/hiiiide/fluentd-ds-cloudlogging.svg)](https://hub.docker.com/r/hiiiide/fluentd-ds-cloudlogging)
-
-
+[![Docker Stars](https://img.shields.io/docker/stars/fablic/fluentd-ds-cloudlogging.svg)](https://hub.docker.com/r/hiiiide/fluentd-ds-cloudlogging)
+[![Docker Pulls](https://img.shields.io/docker/pulls/fablic/fluentd-ds-cloudlogging.svg)](https://hub.docker.com/r/hiiiide/fluentd-ds-cloudlogging)
 
 ## Supported tags and respective `Dockerfile` links
 
-See also dockerhub tags page: https://hub.docker.com/r/hiiiide/fluentd-ds-cloudlogging/tags
+See also dockerhub tags page: https://hub.docker.com/r/fablic/fluentd-ds-cloudlogging/tags
 
 ## Image versions
 
-- `v0.0.1`, `latest`
+- `0.0.1`, `latest`
   - fluentd: 1.7.4
   - fluent-plugin-google-cloud: 0.8.5


### PR DESCRIPTION
It's a forked repository from [hiiiide/docker-fluentd-ds-cloudlogging](https://github.com/hiiiide/docker-fluentd-ds-cloudlogging). I changed README and LICENSE for the Fablic. The dockerhub build when push to master branch or tag 0.0.1 automatically.

[hiiiide/docker-fluentd-ds-cloudlogging](https://github.com/hiiiide/docker-fluentd-ds-cloudlogging)をforkしたリポジトリになります。
Fablic用にREADME, LICENSEを変更しています。
master branch または tag(0.0.1)をpushするとdoockerhub側でimageのbuildが行われます。